### PR TITLE
chore(ci): pin ci-workflows to hash d64a5d5 and unify on ci.yml

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,21 +1,20 @@
 name: Build & Test
+
 on:
     push:
-        branches: [main]
+        branches:
+            - main
     pull_request:
-        branches: [main]
+        branches:
+            - main
+
+env:
+    APP_MODE: "ci"
+    CI: true
 
 jobs:
     ci:
-        uses: DCC-BS/ci-workflows/.github/workflows/frontend-ci.yml@814649735835a84a3d0d6c8d6e6db87dfeb8b348 # v8
+        uses: DCC-BS/ci-workflows/.github/workflows/ci.yml@d64a5d501aaee55d37be82405e03812862d43474
         with:
-            node_version: "24.x"
-            working_directory: "."
-            run_biome: true
-            run_playwright: false
-            install_method: "bun" # 'bun' | 'npm' | 'pnpm' | 'yarn'
-            install_command: "bun install" # optional override; default per install_method
-            build_command: "bun generate"
-            test_command: ""
-            artifact_name: "playwright-report"
-            artifact_retention_days: 30
+            check-command: "mise run check"
+            build-command: "mise run generate"

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -8,7 +8,7 @@ permissions:
 
 jobs:
     publish:
-        uses: DCC-BS/ci-workflows/.github/workflows/npm-publish.yml@814649735835a84a3d0d6c8d6e6db87dfeb8b348 # v8
+        uses: DCC-BS/ci-workflows/.github/workflows/npm-publish.yml@d64a5d501aaee55d37be82405e03812862d43474
         with:
             install_command: bun install
             build_command: bun run generate

--- a/mise.toml
+++ b/mise.toml
@@ -3,6 +3,9 @@ bun = "1.3.0"
 node = "24.9.0"
 usage = "3.5.6"
 
+[hooks]
+postinstall = { task = "install" }
+
 # ── Setup ─────────────────────────────────────────────────────────────────────
 
 [tasks.install]

--- a/mise.toml
+++ b/mise.toml
@@ -62,7 +62,7 @@ run = "bunx biome check --fix"
 
 # ── Testing ───────────────────────────────────────────────────────────────────
 
-[tasks.test]
+[tasks."test:unit"]
 description = "run unit tests"
 run = "bunx vitest"
 

--- a/mise.toml
+++ b/mise.toml
@@ -1,0 +1,87 @@
+[tools]
+bun = "1.3.0"
+node = "24.9.0"
+usage = "3.5.6"
+
+# ── Setup ─────────────────────────────────────────────────────────────────────
+
+[tasks.install]
+description = "install npm packages and prepare the playground"
+run = [
+    "bun install",
+    "bunx nuxt-module-build build --stub",
+    "bunx nuxt-module-build prepare",
+    "bunx nuxi prepare playground",
+]
+
+[tasks."nuxt:prepare"]
+description = "generate Nuxt types for the playground"
+run = "bunx nuxi prepare playground"
+
+# ── Development ───────────────────────────────────────────────────────────────
+
+[tasks.dev]
+description = "start the playground dev server"
+run = "bunx nuxi dev playground"
+
+[tasks."dev:build"]
+description = "build the playground"
+run = "bunx nuxi build playground"
+
+[tasks."dev:prepare"]
+description = "prepare the module for development (stub build + playground types)"
+run = [
+    "bunx nuxt-module-build build --stub",
+    "bunx nuxt-module-build prepare",
+    "bunx nuxi prepare playground",
+]
+
+# ── Build ─────────────────────────────────────────────────────────────────────
+
+[tasks.prepack]
+description = "build the module for packaging"
+run = "bunx nuxt-module-build build"
+
+[tasks.generate]
+description = "generate the playground static site"
+run = "bunx nuxi generate playground"
+
+# ── Type Checking & Linting ───────────────────────────────────────────────────
+
+[tasks.tsc]
+description = "run TypeScript type checking"
+run = "bunx vue-tsc --noEmit"
+
+[tasks.lint]
+description = "format code with Biome"
+run = "bunx biome format --write"
+
+[tasks.check]
+description = "check and fix linting issues"
+run = "bunx biome check --fix"
+
+# ── Testing ───────────────────────────────────────────────────────────────────
+
+[tasks.test]
+description = "run unit tests"
+run = "bunx vitest"
+
+[tasks."test:watch"]
+description = "run unit tests in watch mode"
+run = "bunx vitest --watch"
+
+[tasks."test:types"]
+description = "run TypeScript type checks for module and playground"
+run = "bunx vue-tsc --noEmit && cd playground && bunx vue-tsc --noEmit"
+
+# ── Release ───────────────────────────────────────────────────────────────────
+
+[tasks.release]
+description = "lint, test, build, tag and release"
+run = [
+    "bunx biome check",
+    "bunx vitest run",
+    "bunx nuxt-module-build build",
+    "bunx changelogen --release",
+    "git push --follow-tags",
+]

--- a/package.json
+++ b/package.json
@@ -47,6 +47,6 @@
         "typescript": "~6.0.2",
         "vitest": "^4.1.1",
         "vue-tsc": "^3.2.6",
-        "@biomejs/biome": "^2.4.8"
+        "@biomejs/biome": "2.5.7"
     }
 }


### PR DESCRIPTION
Pin all DCC-BS/ci-workflows references to the newest commit hash `d64a5d501aaee55d37be82405e03812862d43474` instead of mutable tags, and consolidate CI on the unified `ci.yml` (replacing `frontend-ci.yml` and `python-backend-ci.yml`).

- Adds a `postinstall` hook to libs so deps install in the mise-based CI.
- Adds a `build` task and `test:e2e` dependency to audio-recorder.
- Backends and .bs.js libs now run through the shared `ci.yml`, which auto-detects mise tasks.